### PR TITLE
Update BoundariesTransformer to support custom replacement values for boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .vscode
 pytest-coverage.txt
 .coverage
+.venv

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ boundaries_transformer = ds.transformer.BoundariesTransformer(
 )
 ```
 
+```python
+boundaries_transformer = ds.transformer.BoundariesTransformer(
+    lower_bound=0,
+    upper_bound=1000000,
+    lower_value=10,
+    upper_value=1200000
+)
+```
+
+
 ### Estimators
 
 ```python

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -341,3 +341,44 @@ def test_boundaries_transformer():
     assert transformed_X.shape == (10, 1)
     assert transformed_X.columns.tolist() == ["boundaries__price"]
     assert transformed_X["boundaries__price"].tolist() == [2, 2, 3, 4, 5, 6, 7, 8, 9, 9]
+
+
+def test_boundaries_transformer_with_custom_values():
+    X = pd.DataFrame(
+        {
+            "price": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
+
+    ct = ColumnTransformer(
+        [
+            (
+                "boundaries",
+                ds.transformer.BoundariesTransformer(
+                    lower_bound=2,
+                    upper_bound=9,
+                    lower_value=0,
+                    upper_value=99,
+                ),
+                ["price"],
+            )
+        ]
+    ).set_output(transform="pandas")
+
+    transformed_X = ct.fit_transform(X)
+
+    assert transformed_X is not None
+    assert transformed_X.shape == (10, 1)
+    assert transformed_X.columns.tolist() == ["boundaries__price"]
+    assert transformed_X["boundaries__price"].tolist() == [
+        0,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        99,
+    ]


### PR DESCRIPTION
Este PR melhora a classe `BoundariesTransformer`, permitindo que sejam definidos valores de substituição (`lower_value` e `upper_value`) quando os dados ultrapassarem os limites estabelecidos.

### O que mudou

- Antes, valores fora dos limites eram sempre substituídos pelo próprio limite. Agora, se `lower_value` ou `upper_value` forem definidos, eles serão usados como valores de substituição.
- Atualização da documentação para novo caso de uso
- Inclusão de teste para novo caso